### PR TITLE
Add bounds check in setPixel in mini version of library

### DIFF
--- a/mini/img_util.fs
+++ b/mini/img_util.fs
@@ -19,8 +19,10 @@ let format = Imaging.PixelFormat.Format24bppRgb
 // canvas operations
 type canvas = Canvas of System.Drawing.Bitmap
 
+// Set a pixel in canvas if pixel is within bounds
 let setPixel (C c) (x,y) (Canvas bmp) : unit =
-  bmp.SetPixel (x,y,c)
+  if x < 0 || y < 0 || x >= bmp.Width || y >= bmp.Height then ()
+  else bmp.SetPixel (x,y,c)
 
 let getPixel (Canvas bmp) (x,y) : color =
   C(bmp.GetPixel (x,y))


### PR DESCRIPTION
As title says, add a bounds check in mini-version of setPixel, similar to the bounds check in setPixel in the "big" version of the library. 